### PR TITLE
feat: TFActionにおける環境設定の順序を修正

### DIFF
--- a/.github/workflows/schedule-detect-drifts.yaml
+++ b/.github/workflows/schedule-detect-drifts.yaml
@@ -78,15 +78,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
+      - uses: suzuki-shunsuke/tfaction/set-drift-env@80af9c060a3870868c12c31a674e9d8b26278118 # v1.19.1
+        with:
+          issue: ${{toJSON(matrix.issue)}}
+
       # GitHub Secrets を TFAction に渡す Action
       - uses: suzuki-shunsuke/tfaction/js@80af9c060a3870868c12c31a674e9d8b26278118 # v1.19.1
         with:
           action: export-secrets
           secrets: ${{ toJSON(secrets) }}
-
-      - uses: suzuki-shunsuke/tfaction/set-drift-env@80af9c060a3870868c12c31a674e9d8b26278118 # v1.19.1
-        with:
-          issue: ${{toJSON(matrix.issue)}}
 
       - uses: suzuki-shunsuke/tfaction/setup@80af9c060a3870868c12c31a674e9d8b26278118 # v1.19.1
         with:


### PR DESCRIPTION
- `set-drift-env`アクションを`export-secrets`アクションの前に移動し、正しい環境設定を行うようにしました。