### PR TITLE
feat: LXCインスタンスの数を1に変更

### DIFF
--- a/proxmox/lxc_test.tf
+++ b/proxmox/lxc_test.tf
@@ -1,6 +1,6 @@
 resource "proxmox_lxc" "test" {
   # Enable Switch, 1 = true, 0 = false
-  count = 0
+  count = 1
 
   vmid         = 199
   hostname     = "test"


### PR DESCRIPTION
proxmox/lxc_test.tfのcountを0から1に変更し、LXCインスタンスを有効にしました。