### PR TITLE
feat: LXCリソースのカウントを1に変更

### DIFF
--- a/proxmox/lxc_test.tf
+++ b/proxmox/lxc_test.tf
@@ -1,6 +1,6 @@
 resource "proxmox_lxc" "test" {
   # Enable Switch, 1 = true, 0 = false
-  count = 0
+  count = 1
   force = true
 
   vmid         = 199


### PR DESCRIPTION
proxmox/lxc_test.tfのリソース設定で、LXCのカウントを0から1に変更しました。これにより、インスタンスが正しく作成されるようになります。