### PR TITLE
fix: LXCリソースのカウントを0に変更

### DIFF
--- a/proxmox/lxc_test.tf
+++ b/proxmox/lxc_test.tf
@@ -1,6 +1,6 @@
 resource "proxmox_lxc" "test" {
   # Enable Switch, 1 = true, 0 = false
-  count = 1
+  count = 0
 
   vmid         = 199
   hostname     = "test"


### PR DESCRIPTION
- proxmox/lxc_test.tfのリソース設定で、countを1から0に変更しました。